### PR TITLE
Add empty arrays to useEffect calls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,7 +124,7 @@ function App() {
     return () => {
       removeEventListenerGetProgress();
     };
-  });
+  }, []);
 
   const padding = 30;
   return (

--- a/src/components/ChartPanel.tsx
+++ b/src/components/ChartPanel.tsx
@@ -28,7 +28,7 @@ const ChartPanel = (props: { forceTarget: number }) => {
       removeEventListener();
     };
     // window.electronAPI.removeSensorListener(() => {});
-  });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
This should help with performance issues.
The thing is that with useEffect you pass a "dependency array". If it changes then the callback will be called again.
If you wish to run the callback only on mount, an empty array should be passed. When nothing is passed the argument is "undefined" and the callback will be called on **each render** (i.e. on every state change, or anything that happens basically).
I assume some of the callbacks had logic with arduino communications, which are quite heavy in terms of performance.

[https://stackoverflow.com/questions/57760842/why-would-we-use-useeffect-without-a-dependency-array](https://stackoverflow.com/questions/57760842/why-would-we-use-useeffect-without-a-dependency-array)

Another thing is that i've seen a lot of console logs. You should probably check if they are happening in a loop or something (or inside setInterval).

Also I noticed you have [setInterval with a 0.5 millisecond delay](https://github.com/GuyNoimark/tester-controller/blob/3179118a2f0402479a57f0ce0b7d0395c1306af0/src/main.ts#L118).
Check out the [documentation for setInterval](https://www.w3schools.com/jsref/met_win_setinterval.asp) (10 millis is the minimum).